### PR TITLE
Add NestJS backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,4 @@ Yes, you can!
 To connect a domain, navigate to Project > Settings > Domains and click Connect Domain.
 
 Read more here: [Setting up a custom domain](https://docs.lovable.dev/tips-tricks/custom-domain#step-by-step-guide)
+\n## Backend\n\nThe `backend` directory contains a NestJS server configured with TypeORM and PostgreSQL (Supabase). See `backend/README.md` for setup instructions.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,2 @@
+DATABASE_URL=postgresql://user:password@db.host:5432/dbname
+PORT=3000

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,21 @@
+# NestJS Backend
+
+This directory contains a simple NestJS backend using TypeORM and PostgreSQL. It is configured to connect to a Supabase database via the `DATABASE_URL` environment variable.
+
+## Development
+
+```bash
+cd backend
+npm install
+npm run start:dev
+```
+
+The server listens on `PORT` (default: 3000). Example endpoints:
+
+- `GET /` – returns `Hello World!`
+- `GET /tasks` – list tasks
+- `POST /tasks` – create a task with JSON body `{ "title": "..." }`
+
+## Configuration
+
+Copy `.env.example` to `.env` and update your Supabase credentials.

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "backend",
+  "version": "1.0.0",
+  "description": "NestJS backend with TypeORM and PostgreSQL (Supabase)",
+  "scripts": {
+    "start": "nest start",
+    "start:dev": "nest start --watch",
+    "build": "nest build"
+  },
+  "dependencies": {
+    "@nestjs/common": "^10.0.0",
+    "@nestjs/core": "^10.0.0",
+    "@nestjs/platform-express": "^10.0.0",
+    "@nestjs/typeorm": "^10.0.0",
+    "reflect-metadata": "^0.1.13",
+    "rxjs": "^7.8.1",
+    "typeorm": "^0.3.22",
+    "pg": "^8.10.0"
+  },
+  "devDependencies": {
+    "@nestjs/cli": "^10.0.0",
+    "@nestjs/schematics": "^10.0.0",
+    "@nestjs/testing": "^10.0.0",
+    "ts-loader": "^9.4.2",
+    "ts-node": "^10.9.1",
+    "typescript": "^5.5.3"
+  }
+}

--- a/backend/src/app.controller.ts
+++ b/backend/src/app.controller.ts
@@ -1,0 +1,12 @@
+import { Controller, Get } from '@nestjs/common';
+import { AppService } from './app.service';
+
+@Controller()
+export class AppController {
+  constructor(private readonly appService: AppService) {}
+
+  @Get()
+  getHello(): string {
+    return this.appService.getHello();
+  }
+}

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,0 +1,22 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { ConfigModule } from '@nestjs/config';
+import { AppController } from './app.controller';
+import { AppService } from './app.service';
+import { TasksModule } from './tasks/tasks.module';
+
+@Module({
+  imports: [
+    ConfigModule.forRoot({ isGlobal: true }),
+    TypeOrmModule.forRoot({
+      type: 'postgres',
+      url: process.env.DATABASE_URL,
+      autoLoadEntities: true,
+      synchronize: true,
+    }),
+    TasksModule,
+  ],
+  controllers: [AppController],
+  providers: [AppService],
+})
+export class AppModule {}

--- a/backend/src/app.service.ts
+++ b/backend/src/app.service.ts
@@ -1,0 +1,8 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class AppService {
+  getHello(): string {
+    return 'Hello World!';
+  }
+}

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,0 +1,10 @@
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from './app.module';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  const port = process.env.PORT || 3000;
+  await app.listen(port);
+  console.log(`Server running on http://localhost:${port}`);
+}
+bootstrap();

--- a/backend/src/tasks/task.entity.ts
+++ b/backend/src/tasks/task.entity.ts
@@ -1,0 +1,13 @@
+import { Entity, Column, PrimaryGeneratedColumn } from 'typeorm';
+
+@Entity()
+export class Task {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  title: string;
+
+  @Column({ default: false })
+  completed: boolean;
+}

--- a/backend/src/tasks/tasks.controller.ts
+++ b/backend/src/tasks/tasks.controller.ts
@@ -1,0 +1,18 @@
+import { Controller, Get, Post, Body } from '@nestjs/common';
+import { TasksService } from './tasks.service';
+import { Task } from './task.entity';
+
+@Controller('tasks')
+export class TasksController {
+  constructor(private readonly tasksService: TasksService) {}
+
+  @Get()
+  getTasks(): Promise<Task[]> {
+    return this.tasksService.findAll();
+  }
+
+  @Post()
+  createTask(@Body('title') title: string): Promise<Task> {
+    return this.tasksService.create(title);
+  }
+}

--- a/backend/src/tasks/tasks.module.ts
+++ b/backend/src/tasks/tasks.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { TasksController } from './tasks.controller';
+import { TasksService } from './tasks.service';
+import { Task } from './task.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Task])],
+  controllers: [TasksController],
+  providers: [TasksService],
+})
+export class TasksModule {}

--- a/backend/src/tasks/tasks.service.ts
+++ b/backend/src/tasks/tasks.service.ts
@@ -1,0 +1,20 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Task } from './task.entity';
+
+@Injectable()
+export class TasksService {
+  constructor(
+    @InjectRepository(Task) private tasksRepository: Repository<Task>,
+  ) {}
+
+  findAll(): Promise<Task[]> {
+    return this.tasksRepository.find();
+  }
+
+  create(title: string): Promise<Task> {
+    const task = this.tasksRepository.create({ title });
+    return this.tasksRepository.save(task);
+  }
+}

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "declaration": true,
+    "removeComments": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "allowSyntheticDefaultImports": true,
+    "target": "es2017",
+    "sourceMap": true,
+    "outDir": "dist",
+    "baseUrl": "./",
+    "incremental": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary
- add backend README and env sample
- add basic NestJS server with TypeORM and example Task entity
- document backend in main README

## Testing
- `npm run lint` *(fails: Fast refresh and TypeScript lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6841ea659ab8832f8e59786e1bee63e7